### PR TITLE
Update dependencies and remove upper bounds

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,9 +5,7 @@ Unreleased
 ----------
 
 * Add support for observable "Prod".
-* Updated pytket version requirement to 1.28.
-* Updated pennylane version requirement to 0.36.
-* Updated pytket-qiskit version requirement to 0.53.
+* Updated dependencies, removing upper bounds on versions.
 
 
 0.17.0 (April 2024)

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.28",
-        "pennylane ~= 0.36",
-        "pytket-qiskit ~= 0.53",
+        "pytket >= 1.29.2",
+        "pennylane >= 0.37.0",
+        "pytket-qiskit >= 0.54.1",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
Updates to pytket-pennylane 0.37.
