### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -75,7 +75,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request')
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,5 +2,20 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.pennylane
-    :special-members:
-    :members: PytketDevice, pennylane_to_tk
+.. automodule:: pytket.extensions.pennylane._metadata
+.. automodule:: pytket.extensions.pennylane.pytket_device
+
+    .. autoclass:: PytketDevice
+
+       .. automethod:: analytic_probability
+       .. automethod:: apply
+       .. automethod:: capabilities
+       .. automethod:: compile
+       .. automethod:: generate_samples
+       .. automethod:: reset
+       .. automethod:: run
+
+.. automodule:: pytket.extensions.pennylane.pennylane_convert
+
+    .. autofunction:: pennylane_to_tk
+    .. autofunction:: apply_operations

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/pytket/extensions/pennylane/pennylane_convert.py
+++ b/pytket/extensions/pennylane/pennylane_convert.py
@@ -58,8 +58,7 @@ def apply_operations(
         operations (List[pennylane.operation.Operation]): operations to be applied
 
     Returns:
-        list[Circuit]: a list of tket circuit objects that
-            specify the corresponding operations
+        A list of tket circuit objects that specify the corresponding operations
     """
     circuits = []
 

--- a/pytket/extensions/pennylane/pennylane_convert.py
+++ b/pytket/extensions/pennylane/pennylane_convert.py
@@ -55,7 +55,7 @@ def apply_operations(
     This method serves as an auxiliary method to :meth:`~.PytketDevice.apply`.
 
     Args:
-        operations (List[pennylane.Operation]): operations to be applied
+        operations (List[pennylane.operation.Operation]): operations to be applied
 
     Returns:
         list[Circuit]: a list of tket circuit objects that

--- a/pytket/extensions/pennylane/pytket_device.py
+++ b/pytket/extensions/pennylane/pytket_device.py
@@ -58,19 +58,14 @@ class PytketDevice(QubitDevice):
         execute circuits.
 
         :param wires: Number of wires
-        :type wires: int
         :param shots: Number of shots to use (only relevant for sampling backends),
             defaults to None
-        :type shots: Optional[int], optional
         :param pytket_backend: Pytket Backend class to use, defaults to
             AerStateBackend() to facilitate automated pennylane testing of this backend
-        :type pytket_backend: Backend, optional
         :param optimisation_level: Backend default compilation optimisation level,
             ignored if `compilation_pass` is set, defaults to None
-        :type optimisation_level: int, optional
         :param compilation_pass: Pytket compiler pass with which to compile circuits,
             defaults to None
-        :type compilation_pass: Optional[BasePass], optional
         :raises ValueError: If the Backend does not support shots or state results
         """
 
@@ -89,6 +84,7 @@ class PytketDevice(QubitDevice):
         super().__init__(wires=wires, shots=shots)
 
     def capabilities(self) -> dict[str, Any]:
+        """See :py:meth:`pennylane.devices._qubit_device.QubitDevice.capabilities`"""
         cap_dic: dict[str, Any] = super().capabilities().copy()
         cap_dic.update(
             {
@@ -113,6 +109,7 @@ class PytketDevice(QubitDevice):
     def apply(
         self, operations: list[Operation], rotations: list[Operation] | None = None
     ) -> None:
+        """See :py:meth:`pennylane.devices._qubit_device.QubitDevice.apply`"""
         self._circuit = pennylane_to_tk(
             operations if rotations is None else operations + rotations,
             self._wire_map,
@@ -142,10 +139,12 @@ class PytketDevice(QubitDevice):
     def analytic_probability(
         self, wires: int | Iterable[int] | None = None
     ) -> np.ndarray:
+        """See :py:meth:`pennylane.devices._qubit_device.QubitDevice.analytic_probability`"""
         prob = self.marginal_prob(np.abs(self.state) ** 2, wires)
         return cast("np.ndarray", prob)
 
     def generate_samples(self) -> np.ndarray:
+        """See :py:meth:`pennylane.devices._qubit_device.QubitDevice.generate_samples`"""
         if self.pytket_backend.supports_shots:
             if self._backres is None:
                 raise RuntimeError("Result does not exist.")


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
